### PR TITLE
Fix crash on config repo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bash_completion.sh
 .output
 .uptodate
+/.dir-locals.el

--- a/compare-revisions.cabal
+++ b/compare-revisions.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -116,15 +116,18 @@ test-suite tasty
       base >= 4.9 && < 5
     , protolude
     , compare-revisions
+    , filepath
     , hspec
     , QuickCheck
     , tasty
     , tasty-hspec
+    , temporary
     , text
     , yaml
   other-modules:
       Config
       Duration
+      Git
       Regex
       SCP
   default-language: Haskell2010

--- a/compare-revisions.cabal
+++ b/compare-revisions.cabal
@@ -119,6 +119,7 @@ test-suite tasty
     , filepath
     , hspec
     , QuickCheck
+    , directory
     , tasty
     , tasty-hspec
     , temporary

--- a/package.yaml
+++ b/package.yaml
@@ -82,6 +82,7 @@ tests:
       - filepath
       - hspec
       - QuickCheck
+      - directory
       - tasty
       - tasty-hspec
       - temporary

--- a/package.yaml
+++ b/package.yaml
@@ -79,9 +79,11 @@ tests:
     source-dirs: tests
     dependencies:
       - compare-revisions
+      - filepath
       - hspec
       - QuickCheck
       - tasty
       - tasty-hspec
+      - temporary
       - text
       - yaml

--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -164,7 +164,7 @@ ensureCheckout repoPath branch workTreePath = do
         Log.debug' $ "Added work tree at " <> toS path
 
     removeWorkTree path = do
-      liftIO $ unlessM (fileExist path) $ removeDirectoryRecursive path
+      void $ liftIO $ tryJust (guard . isDoesNotExistError) (removeDirectoryRecursive path)
       void $ runGitInRepo repoPath ["worktree", "prune"]
       Log.debug' $ "Removed worktree from " <> toS path
 

--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -188,7 +188,9 @@ ensureCheckout repoPath branch workTreePath = do
            Log.debug' $ "Renaming " <> toS tmpLink <> " to " <> toS linkPath
            rename (base </> "tmp-link") linkPath
            Log.debug' $ "Swapped symlink: " <> toS linkPath <> " now points to " <> toS newPath
-           pure currentPath
+           pure $ case currentPath of
+             Nothing -> Nothing
+             Just p -> Just (base </> p)
 
     getSymlink :: HasCallStack => FilePath -> IO (Maybe FilePath)
     getSymlink path = do

--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -12,6 +12,9 @@ module CompareRevisions.Git
   , ensureCheckout
   , syncRepo
   , getLog
+  -- * Exported for testing purposes
+  , runGit
+  , runGitInRepo
   ) where
 
 import Protolude

--- a/tests/Git.hs
+++ b/tests/Git.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Git (tests) where
+
+import Protolude
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+
+import qualified CompareRevisions.Git as Git
+import CompareRevisions.Server.Logging (withLogging, LogLevel(..))
+
+tests :: IO TestTree
+tests = testSpec "Git" $
+  describe "ensureCheckout" $
+    it "checks out a repository" $ withLogging LevelError $ withSystemTempDirectory "base-directory" $ \baseDir -> do
+      let repoDir = baseDir </> "repo"
+      void $ gitOp $ Git.runGit ["init", toS repoDir]
+      writeFile (repoDir </> "hello") "dummy content"
+      void $ gitOp $ Git.runGitInRepo repoDir ["add", "hello"]
+      void $ gitOp $ Git.runGitInRepo repoDir ["commit", "-m", "Initial commit"]
+      let workingTreeDir = baseDir </> "working-tree"
+      void $ gitOp $ Git.ensureCheckout repoDir (Git.Branch "master") workingTreeDir
+      contents <- readFile (workingTreeDir </> "hello")
+      contents `shouldBe` "dummy content"
+
+
+gitOp :: Monad m => ExceptT Git.GitError m a -> m a
+gitOp op = do
+  result <- runExceptT op
+  case result of
+    Left err -> panic $ "git operation failed: " <> show err
+    Right res -> pure res

--- a/tests/Git.hs
+++ b/tests/Git.hs
@@ -42,7 +42,10 @@ git :: MonadIO m => FilePath -> [Text] -> m ()
 git repo args = gitOp $ Git.runGitInRepo repo args
 
 gitInit :: MonadIO m => FilePath -> m ()
-gitInit repoDir = gitOp $ Git.runGit ["init", toS repoDir]
+gitInit repoDir = do
+  gitOp $ Git.runGit ["init", toS repoDir]
+  git repoDir ["config", "user.name", "testuser"]
+  git repoDir ["config", "user.email", "testuser@example.com"]
 
 gitOp :: Monad m => ExceptT Git.GitError m a -> m ()
 gitOp op = do

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -8,6 +8,7 @@ import Test.Tasty (defaultMain, testGroup)
 
 import qualified Config
 import qualified Duration
+import qualified Git
 import qualified Regex
 import qualified SCP
 
@@ -21,4 +22,5 @@ main = do
       , Duration.tests
       , Config.tests
       , Regex.tests
+      , Git.tests
       ]


### PR DESCRIPTION
We were getting crashes on config repo update, due to `swapSymlink` returning a relative path that we then passed to `removeDirectoryRecursive`. 

We should not have got to `removeDirectoryRecursive` at all, but the check `unlessM (fileExist path) action` means "do `action` unless `path` exists", i.e. "only do `action` if `path` doesn't exist". That is, I got my booleans backwards. Oops.

I've replaced that check with something that just removes the directory regardless and catches the "doesn't exist" exception. This has the benefit of being more correct. 

Also wrote some tests, since the file-on-disk stuff is quite statey.

I'll merge this tomorrow unless someone reviews before then.