### PR TITLE
Update to latest Stack LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-9.21
+      # Update stack.yaml when you change this.
+      - image: fpco/stack-build:lts-11.1
     steps:
       - checkout
       - restore_cache:

--- a/cmd/compare-images/Main.hs
+++ b/cmd/compare-images/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Protolude
+import Protolude hiding (diff)
 
 import qualified Data.Map as Map
 import Options.Applicative

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -11,7 +11,7 @@ module CompareRevisions.API
   , server
   ) where
 
-import Protolude
+import Protolude hiding (diff)
 
 import Data.Aeson (ToJSON(..))
 import qualified Data.Map as Map

--- a/src/CompareRevisions/Config.hs
+++ b/src/CompareRevisions/Config.hs
@@ -17,7 +17,7 @@ module CompareRevisions.Config
   , getRepoPath
   ) where
 
-import Protolude hiding (Identity)
+import Protolude hiding (Identity, hash, option)
 
 import Control.Monad.Fail (fail)
 import Crypto.Hash (hash, Digest, SHA256)

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -9,7 +9,7 @@ module CompareRevisions.Engine
   , getCurrentDifferences
   ) where
 
-import Protolude
+import Protolude hiding (diff, throwE)
 
 import Control.Concurrent.STM (TVar, newTVarIO, readTVar, writeTVar)
 import qualified Control.Logging as Log

--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -17,7 +17,7 @@ module CompareRevisions.Git
   , runGitInRepo
   ) where
 
-import Protolude
+import Protolude hiding (hash)
 
 import qualified Control.Logging as Log
 import qualified Data.ByteString.Char8 as ByteString

--- a/src/CompareRevisions/Kube.hs
+++ b/src/CompareRevisions/Kube.hs
@@ -21,7 +21,7 @@ module CompareRevisions.Kube
   , getImageName
   ) where
 
-import Protolude
+import Protolude hiding (diff)
 
 import qualified Data.Aeson as Aeson
 import Data.Aeson (Value(..))

--- a/src/CompareRevisions/Server.hs
+++ b/src/CompareRevisions/Server.hs
@@ -5,10 +5,10 @@ module CompareRevisions.Server
   , run
   ) where
 
-import Protolude
+import Protolude hiding (option)
 
 import qualified Control.Logging as Log
-import GHC.Stats (getGCStatsEnabled)
+import GHC.Stats (getRTSStatsEnabled)
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Middleware.RequestLogger as RL
 import Options.Applicative
@@ -67,7 +67,7 @@ run :: Config -> Application -> IO ()
 run config@Config{..} app = do
   requests <- Prom.registerIO requestDuration
   when enableGhcMetrics $
-    do statsEnabled <- getGCStatsEnabled
+    do statsEnabled <- getRTSStatsEnabled
        unless statsEnabled $
          Log.warn' "Exporting GHC metrics but GC stats not enabled. Re-run with +RTS -T."
        void $ Prom.register Prom.ghcMetrics

--- a/src/CompareRevisions/Server/Logging.hs
+++ b/src/CompareRevisions/Server/Logging.hs
@@ -8,7 +8,7 @@ module CompareRevisions.Server.Logging
   , error'
   ) where
 
-import Protolude
+import Protolude hiding (option)
 
 import Control.Logging
   ( LogLevel(..)

--- a/src/CompareRevisions/Validator.hs
+++ b/src/CompareRevisions/Validator.hs
@@ -10,8 +10,9 @@ module CompareRevisions.Validator
   , mapErrors
   ) where
 
-import Protolude
+import Protolude hiding (throwE, (<>))
 
+import Data.Semigroup ((<>))
 import Data.List.NonEmpty (NonEmpty(..))
 
 -- | A 'Validator' is a value that can either be valid or have a non-empty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.21
+resolver: lts-11.1
 
 packages:
   - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
+# Update CircleCI config when you change this.
 resolver: lts-11.1
 
 packages:


### PR DESCRIPTION
This bumps the compiler version to GHC 8.2, and also updates a variety of library dependencies.

One implication is that we need to hide more imports from protolude, as they clash with names chosen in the code-base.