### PR TITLE
Refactor Engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-9.21
+      # Update stack.yaml when you change this.
+      - image: fpco/stack-build:lts-11.1
     steps:
       - checkout
       - restore_cache:

--- a/cmd/compare-images/Main.hs
+++ b/cmd/compare-images/Main.hs
@@ -25,7 +25,7 @@ formatDiff = Map.foldMapWithKey formatSingleDiff
     formatSingleDiff kubeObj diffs =
       mconcat ([ formatKubeObject kubeObj, "\n" ] <>
                [ "  " <> formatImageDiff diff <> "\n" | diff <- diffs ]) <> "\n"
-    formatKubeObject (KubeObject namespace kind name) = namespace <> "/" <> name <> " (" <> kind <> ")"
+    formatKubeObject (KubeObject namespace kind name _) = namespace <> "/" <> name <> " (" <> kind <> ")"
 
     formatImage name label = name <> ":" <> fromMaybe "default" label
 

--- a/cmd/compare-images/Main.hs
+++ b/cmd/compare-images/Main.hs
@@ -5,7 +5,7 @@ import Protolude hiding (diff)
 import qualified Data.Map as Map
 import Options.Applicative
 import CompareRevisions.Kube
-  ( KubeObject(..)
+  ( KubeID(..)
   , ImageDiff(..)
   , loadEnvFromDisk
   , getDifferingImages
@@ -19,13 +19,13 @@ options = Config
   <$> argument str (metavar "SOURCE" <> help "The environment with the newer images.")
   <*> argument str (metavar "DESTINATION" <> help "The environment with the older images.")
 
-formatDiff :: Map KubeObject [ImageDiff] -> Text
+formatDiff :: Map KubeID [ImageDiff] -> Text
 formatDiff = Map.foldMapWithKey formatSingleDiff
   where
     formatSingleDiff kubeObj diffs =
       mconcat ([ formatKubeObject kubeObj, "\n" ] <>
                [ "  " <> formatImageDiff diff <> "\n" | diff <- diffs ]) <> "\n"
-    formatKubeObject (KubeObject namespace kind name _) = namespace <> "/" <> name <> " (" <> kind <> ")"
+    formatKubeObject (KubeID namespace kind name) = namespace <> "/" <> name <> " (" <> kind <> ")"
 
     formatImage name label = name <> ":" <> fromMaybe "default" label
 

--- a/cmd/compare-images/Main.hs
+++ b/cmd/compare-images/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Protolude
+import Protolude hiding (diff)
 
 import qualified Data.Map as Map
 import Options.Applicative

--- a/compare-revisions.cabal
+++ b/compare-revisions.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 177cbb296edf885a8a793635a1d84451b65f52abba84442ebe10bc447596d923
+-- hash: b4af1259f284c1b81088e0dcaa964ae1faaf196359a0199e84f7db3660e1bfbe
 
 name:           compare-revisions
 version:        0.1.0
@@ -124,6 +124,7 @@ test-suite tasty
       QuickCheck
     , base >=4.9 && <5
     , compare-revisions
+    , containers
     , directory
     , filepath
     , hspec
@@ -137,6 +138,7 @@ test-suite tasty
       Config
       Duration
       Git
+      Kube
       Regex
       SCP
       Paths_compare_revisions

--- a/compare-revisions.cabal
+++ b/compare-revisions.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b4af1259f284c1b81088e0dcaa964ae1faaf196359a0199e84f7db3660e1bfbe
+-- hash: 92991c49e4ae99bda52e1c345323c21f1a7bdd9985fa7d1f2437c58349a650cb
 
 name:           compare-revisions
 version:        0.1.0
@@ -30,6 +30,7 @@ library
       QuickCheck
     , aeson
     , array
+    , async
     , attoparsec
     , base >=4.9 && <5
     , bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ library:
   dependencies:
     - aeson
     - array
+    - async
     - attoparsec
     - bytestring
     - containers

--- a/package.yaml
+++ b/package.yaml
@@ -79,6 +79,7 @@ tests:
     source-dirs: tests
     dependencies:
       - compare-revisions
+      - containers
       - filepath
       - hspec
       - QuickCheck

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -11,7 +11,7 @@ module CompareRevisions.API
   , server
   ) where
 
-import Protolude
+import Protolude hiding (diff)
 
 import Data.Aeson (ToJSON(..))
 import qualified Data.Map as Map

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -42,7 +42,10 @@ api = Proxy
 
 -- | API implementation.
 server :: URI -> Engine.ClusterDiffer -> Server API
-server externalURL clusterDiffer = images clusterDiffer :<|> revisions clusterDiffer :<|> pure (RootPage externalURL)
+server externalURL clusterDiffer
+  = images clusterDiffer
+  :<|> revisions clusterDiffer
+  :<|> pure (RootPage externalURL)
 
 -- | Show how images differ between two environments.
 images :: HasCallStack => Engine.ClusterDiffer -> Handler ImageDiffs

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -88,16 +88,16 @@ instance L.ToHtml RootPage where
           Just path' -> toS (uriToString identity (path' `relativeTo` externalURL) "")
 
 
-newtype ImageDiffs = ImageDiffs (Maybe (Map Kube.KubeObject [Kube.ImageDiff])) deriving (Eq, Ord, Show, Generic)
+newtype ImageDiffs = ImageDiffs (Maybe (Map Kube.KubeID [Kube.ImageDiff])) deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON ImageDiffs where
   -- I *think* we can't get a default instance because Aeson cowardly refuses
   -- to objects where the keys are objects.
   toJSON (ImageDiffs diffs) = toJSON (Map.fromList . map reshapeKeys . Map.toList <$> diffs)
     where
-      reshapeKeys (kubeObj, diff) =
-        ( Kube.namespacedName kubeObj
-        , Map.fromList [ ("kind" :: Text, toJSON (Kube.kind kubeObj))
+      reshapeKeys (kubeID, diff) =
+        ( Kube.namespacedName kubeID
+        , Map.fromList [ ("kind" :: Text, toJSON (Kube.kind kubeID))
                        , ("diff", toJSON diff)
                        ]
         )

--- a/src/CompareRevisions/Config.hs
+++ b/src/CompareRevisions/Config.hs
@@ -17,7 +17,7 @@ module CompareRevisions.Config
   , getRepoPath
   ) where
 
-import Protolude hiding (Identity)
+import Protolude hiding (Identity, hash, option)
 
 import Control.Monad.Fail (fail)
 import Crypto.Hash (hash, Digest, SHA256)

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -9,7 +9,7 @@ module CompareRevisions.Engine
   , getCurrentDifferences
   ) where
 
-import Protolude
+import Protolude hiding (diff, throwE)
 
 import Control.Concurrent.STM (TVar, newTVarIO, readTVar, writeTVar)
 import qualified Control.Logging as Log

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
+-- | The heart of compare-revisions
+--
+-- The application's main core is 'ClusterDiffer', which is responsible for
+-- repeatedly updating the 'ClusterDiff'--a static representation of the
+-- differences between two clusters.
 module CompareRevisions.Engine
   ( Error(..)
   , ClusterDiffer
@@ -49,10 +54,15 @@ initMetrics = Metrics
                                                 "comparerevisions_config_file_changes_total"
                                                 "Number of config file changes detected"))))
 
+-- | An error that occurs while comparing repositories
 data Error
-  = InvalidConfig Config.Error
+  = -- | The configuration file was broken somehow.
+    InvalidConfig Config.Error
+    -- | One of the regexes in the config file could not be applied.
   | RegexError RegexReplace Text
+    -- | We could not fetch Git repositories or calculate Git logs.
   | GitError Git.GitError
+    -- | We could not figure out Git information for the given image.
   | NoConfigForImage Kube.ImageName
   deriving (Show)
 
@@ -66,6 +76,12 @@ data ClusterDiff
  deriving (Show)
 
 -- | Core application for comparing revisions of images.
+--
+-- Once run (with 'runClusterDiffer'), it will run in a loop, forever updating
+-- the cluster diff ('updateClusterDiff'). The current diff can be got with
+-- 'getCurrentDifferences'.
+--
+-- Construct with 'newClusterDiffer'.
 data ClusterDiffer
   = ClusterDiffer
   { gitRepoDir :: FilePath  -- ^ Path to where we'll put the Git repositories.
@@ -113,6 +129,7 @@ updateClusterDiff differ@ClusterDiffer{..} = do
   newDiff <- calculateClusterDiff differ
   liftIO . atomically $ writeTVar diff (Just newDiff)
 
+-- | The configuration file has changed.
 configFileChanged :: (Prom.MonadMonitor m, MonadIO m) => ClusterDiffer -> Event -> m ()
 configFileChanged _ (Removed _ _) = pass
 configFileChanged _ (Added _ _) = pass
@@ -129,6 +146,7 @@ configFileChanged ClusterDiffer{..} (Modified path _) = do
   Prom.withLabel status Prom.incCounter . configFileChanges $ metrics
 
 
+-- | A log command to run. Has the start revision, end revision, and an optional set of paths to restrict the log to.
 data LogSpec = LogSpec Git.RevSpec Git.RevSpec (Maybe [FilePath]) deriving (Eq, Ord, Show)
 
 -- | Calculate a new diff between clusters.
@@ -221,6 +239,7 @@ fetchGitLogs gitRepoDir = mapWithKeyConcurrently compareManyRevs
 
 
 -- | Run a function on every key in a map at the same time.
+-- Result is a new map with the same keys but different values.
 mapWithKeyConcurrently
   :: MonadIO io
   => (k -> a -> IO b) -- ^ The function to run concurrently. 'k' is the key, and 'a' is the value of that key.
@@ -237,9 +256,14 @@ syncRepo repoRoot url = do
   where
     repoPath = Config.getRepoPath repoRoot url
 
-compareImages :: MonadIO io => FilePath -> Config.ValidConfig -> ExceptT Error io (Map Kube.KubeID [Kube.ImageDiff])
-compareImages gitRepoDir Config.ValidConfig{..} = withExceptT GitError $ do
-  let Config.ConfigRepo{..} = configRepo
+-- | Find the images that differ between two Kubernetes environments.
+compareImages
+  :: MonadIO io
+  => FilePath  -- ^ Where all of the Git repositories are
+  -> Config.ValidConfig  -- ^ The configuration for the entire application
+  -> ExceptT Error io (Map Kube.KubeID [Kube.ImageDiff])  -- ^ A map of Kubernetes objects to lists of differences between images.
+compareImages gitRepoDir Config.ValidConfig{configRepo} = withExceptT GitError $ do
+  let Config.ConfigRepo{url, branch, sourceEnv, targetEnv} = configRepo
   repoPath <- syncRepo gitRepoDir url
   Git.ensureCheckout repoPath (fromMaybe (Git.Branch "master") branch) checkoutPath
   Kube.getDifferingImages <$> loadEnv sourceEnv <*> loadEnv targetEnv

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -25,7 +25,6 @@ import qualified CompareRevisions.Config as Config
 import qualified CompareRevisions.Duration as Duration
 import qualified CompareRevisions.Git as Git
 import qualified CompareRevisions.Kube as Kube
-import CompareRevisions.Kube (KubeObject(..), ImageDiff(..))
 import CompareRevisions.Regex (RegexReplace, regexReplace)
 
 -- TODO: Metrics for comparing revisions.
@@ -60,7 +59,7 @@ data Error
 data ClusterDiff
  = ClusterDiff
  { revisionDiffs :: Map Kube.ImageName (Either Error [Git.Revision])
- , imageDiffs :: Map KubeObject [ImageDiff]
+ , imageDiffs :: Map Kube.KubeObject [Kube.ImageDiff]
  }
  deriving (Show)
 
@@ -209,7 +208,7 @@ syncRepo repoRoot url = do
   where
     repoPath = Config.getRepoPath repoRoot url
 
-compareImages :: MonadIO io => FilePath -> Config.ValidConfig -> ExceptT Error io (Map KubeObject [ImageDiff])
+compareImages :: MonadIO io => FilePath -> Config.ValidConfig -> ExceptT Error io (Map Kube.KubeObject [Kube.ImageDiff])
 compareImages gitRepoDir Config.ValidConfig{..} = withExceptT GitError $ do
   let Config.ConfigRepo{..} = configRepo
   repoPath <- syncRepo gitRepoDir url

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -59,7 +59,7 @@ data Error
 data ClusterDiff
  = ClusterDiff
  { revisionDiffs :: Map Kube.ImageName (Either Error [Git.Revision])
- , imageDiffs :: Map Kube.KubeObject [Kube.ImageDiff]
+ , imageDiffs :: Map Kube.KubeID [Kube.ImageDiff]
  }
  deriving (Show)
 
@@ -208,7 +208,7 @@ syncRepo repoRoot url = do
   where
     repoPath = Config.getRepoPath repoRoot url
 
-compareImages :: MonadIO io => FilePath -> Config.ValidConfig -> ExceptT Error io (Map Kube.KubeObject [Kube.ImageDiff])
+compareImages :: MonadIO io => FilePath -> Config.ValidConfig -> ExceptT Error io (Map Kube.KubeID [Kube.ImageDiff])
 compareImages gitRepoDir Config.ValidConfig{..} = withExceptT GitError $ do
   let Config.ConfigRepo{..} = configRepo
   repoPath <- syncRepo gitRepoDir url

--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -17,7 +17,7 @@ module CompareRevisions.Git
   , runGitInRepo
   ) where
 
-import Protolude
+import Protolude hiding (hash)
 
 import qualified Control.Logging as Log
 import qualified Data.ByteString.Char8 as ByteString

--- a/src/CompareRevisions/Kube.hs
+++ b/src/CompareRevisions/Kube.hs
@@ -4,6 +4,7 @@ module CompareRevisions.Kube
   ( -- * Objects in Kubernetes
     KubeObject(..)
   , namespacedName
+  , getImageSet
     -- * Environments
   , Env
   , loadEnvFromDisk

--- a/src/CompareRevisions/Kube.hs
+++ b/src/CompareRevisions/Kube.hs
@@ -110,28 +110,6 @@ type ImageName = Text
 type ImageLabel = Text
 
 -- | A set of images is map from names of images to optional labels.
-
--- | Get all the names of images within a JSON value.
-getImageNames :: Value -> [Text]
-getImageNames (Object obj) =
-  image <> rest
-  where
-    image =
-      case HashMap.lookup "image" obj of
-        Just (String name) -> [name]
-        _ -> []
-    rest = concatMap getImageNames obj
-getImageNames (Array arr) = concatMap getImageNames arr
-getImageNames _ = []
-
-
--- | Parse an image name.
-parseImageName :: Text -> Maybe Image
-parseImageName imageName =
-  case splitOn ":" imageName of
-    [name] -> Just (Image name Nothing)
-    [name, label] -> Just (Image name (Just label))
-    _ -> Nothing
 type ImageSet = Map ImageName (Maybe ImageLabel)
 
 -- | Get the images from a Kubernetes object definition.
@@ -144,6 +122,24 @@ getImageSet value =
   where
     images = mapMaybe parseImageName (getImageNames value)
 
+    -- | Get all the names of images within a JSON value.
+    getImageNames (Object obj) =
+      image <> rest
+      where
+        image =
+          case HashMap.lookup "image" obj of
+            Just (String name) -> [name]
+            _ -> []
+        rest = concatMap getImageNames obj
+    getImageNames (Array arr) = concatMap getImageNames arr
+    getImageNames _ = []
+
+    -- | Parse an image name.
+    parseImageName imageName =
+      case splitOn ":" imageName of
+        [name] -> Just (Image name Nothing)
+        [name, label] -> Just (Image name (Just label))
+        _ -> Nothing
 
 -- | Possible difference between image sets.
 data ImageDiff

--- a/src/CompareRevisions/Kube.hs
+++ b/src/CompareRevisions/Kube.hs
@@ -21,7 +21,7 @@ module CompareRevisions.Kube
   , getImageName
   ) where
 
-import Protolude
+import Protolude hiding (diff)
 
 import qualified Data.Aeson as Aeson
 import Data.Aeson (Value(..))

--- a/src/CompareRevisions/Server.hs
+++ b/src/CompareRevisions/Server.hs
@@ -5,10 +5,10 @@ module CompareRevisions.Server
   , run
   ) where
 
-import Protolude
+import Protolude hiding (option)
 
 import qualified Control.Logging as Log
-import GHC.Stats (getGCStatsEnabled)
+import GHC.Stats (getRTSStatsEnabled)
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Middleware.RequestLogger as RL
 import Options.Applicative
@@ -67,7 +67,7 @@ run :: Config -> Application -> IO ()
 run config@Config{..} app = do
   requests <- Prom.registerIO requestDuration
   when enableGhcMetrics $
-    do statsEnabled <- getGCStatsEnabled
+    do statsEnabled <- getRTSStatsEnabled
        unless statsEnabled $
          Log.warn' "Exporting GHC metrics but GC stats not enabled. Re-run with +RTS -T."
        void $ Prom.register Prom.ghcMetrics

--- a/src/CompareRevisions/Server/Logging.hs
+++ b/src/CompareRevisions/Server/Logging.hs
@@ -8,7 +8,7 @@ module CompareRevisions.Server.Logging
   , error'
   ) where
 
-import Protolude
+import Protolude hiding (option)
 
 import Control.Logging
   ( LogLevel(..)

--- a/src/CompareRevisions/Validator.hs
+++ b/src/CompareRevisions/Validator.hs
@@ -10,8 +10,9 @@ module CompareRevisions.Validator
   , mapErrors
   ) where
 
-import Protolude
+import Protolude hiding (throwE, (<>))
 
+import Data.Semigroup ((<>))
 import Data.List.NonEmpty (NonEmpty(..))
 
 -- | A 'Validator' is a value that can either be valid or have a non-empty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.21
+resolver: lts-11.1
 
 packages:
   - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
+# Update CircleCI config when you change this.
 resolver: lts-11.1
 
 packages:

--- a/tests/Kube.hs
+++ b/tests/Kube.hs
@@ -1,0 +1,78 @@
+module Kube (tests) where
+
+import Protolude
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.String (String)
+import qualified Data.Yaml as Yaml
+import qualified Data.Text as Text
+import Test.Hspec.QuickCheck (prop)
+import qualified Test.QuickCheck as QuickCheck
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+
+import qualified CompareRevisions.Kube as Kube
+
+
+kubeObjects :: QuickCheck.Gen Kube.KubeObject
+kubeObjects =
+  Kube.KubeObject <$> text <*> text <*> text <*> QuickCheck.listOf images'
+
+images' :: QuickCheck.Gen Kube.Image
+images' =
+  Kube.Image <$> text <*> QuickCheck.oneof [ pure Nothing
+                                           , Just <$> text
+                                           ]
+
+text :: QuickCheck.Gen Text
+text = toS <$> (QuickCheck.arbitrary :: QuickCheck.Gen String)
+
+
+tests :: IO TestTree
+tests = testSpec "Kube" $ do
+  describe "Parser" $
+    it "parses normal YAML files" $ do
+      let parsed = Yaml.decodeEither (toS example)
+      parsed `shouldBe` Right Kube.KubeObject
+        { namespace = "cortex"
+        , name = "ruler"
+        , kind = "Deployment"
+        , images = [ Kube.Image { name = "quay.io/weaveworks/cortex-ruler"
+                                , label = Just "master-f7f6cf9e"
+                                }
+                   ]
+        }
+  describe "Image Sets" $ do
+    prop "Image set has all image names" $
+      QuickCheck.forAll kubeObjects $ \obj ->
+      Set.fromList [ Kube.Image n l | (n, l) <- Map.toList (Kube.getImageSet obj) ] `Set.isSubsetOf` Set.fromList (Kube.images obj)
+    it "Finds all the images in our example" $ do
+      let Right obj = Yaml.decodeEither (toS example)
+      Kube.getImageSet obj `shouldBe` Map.fromList [("quay.io/weaveworks/cortex-ruler", Just "master-f7f6cf9e")]
+
+
+example :: Text
+example = Text.unlines
+          [ "---"
+          , "apiVersion: extensions/v1beta1"
+          , "kind: Deployment"
+          , "metadata:"
+          , "  name: ruler"
+          , "  namespace: cortex"
+          , "spec:"
+          , "  replicas: 1"
+          , "  template:"
+          , "    metadata:"
+          , "      labels:"
+          , "        name: ruler"
+          , "    spec:"
+          , "      containers:"
+          , "      - name: ruler"
+          , "        image: quay.io/weaveworks/cortex-ruler:master-f7f6cf9e"
+          , "        imagePullPolicy: IfNotPresent"
+          , "        args:"
+          , "        - -server.http-listen-port=80"
+          , "        ports:"
+          , "        - containerPort: 80"
+          ]

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -9,6 +9,7 @@ import Test.Tasty (defaultMain, testGroup)
 import qualified Config
 import qualified Duration
 import qualified Git
+import qualified Kube
 import qualified Regex
 import qualified SCP
 
@@ -23,4 +24,5 @@ main = do
       , Config.tests
       , Regex.tests
       , Git.tests
+      , Kube.tests
       ]


### PR DESCRIPTION
The Engine module is the guts of compare-revisions, and I found it a little hard to follow when coming back to it. I hope these changes make it more clear and more useful than just to me:

- Take the `calculateClusterDiff` function and break it up into clear `compareImages` and `compareRevisions` parts
- Rework the somewhat complex parallelisation logic of `compareRevisions` so it's all in one place
- Move the bit that does the actual work of `compareRevisions` into `fetchGitLogs`
- More documentation everywhere
- In general, change functions to take the specific parameters they need, rather than large "config" objects

Depends on #31 