### PR TITLE
New cluster changelog page

### DIFF
--- a/compare-revisions.cabal
+++ b/compare-revisions.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 92991c49e4ae99bda52e1c345323c21f1a7bdd9985fa7d1f2437c58349a650cb
+-- hash: 71f6c2c9ccbfd7ed7a25467f36b1d6a7d269f13787947e5aec7e88ca9f22398a
 
 name:           compare-revisions
 version:        0.1.0
@@ -32,6 +32,7 @@ library
     , array
     , async
     , attoparsec
+    , attoparsec-iso8601
     , base >=4.9 && <5
     , bytestring
     , containers
@@ -124,6 +125,7 @@ test-suite tasty
   build-depends:
       QuickCheck
     , base >=4.9 && <5
+    , bytestring
     , compare-revisions
     , containers
     , directory
@@ -134,6 +136,7 @@ test-suite tasty
     , tasty-hspec
     , temporary
     , text
+    , time
     , yaml
   other-modules:
       Config

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ library:
     - array
     - async
     - attoparsec
+    - attoparsec-iso8601
     - bytestring
     - containers
     - cryptonite
@@ -79,6 +80,7 @@ tests:
     main: Tasty.hs
     source-dirs: tests
     dependencies:
+      - bytestring
       - compare-revisions
       - containers
       - filepath
@@ -89,4 +91,5 @@ tests:
       - tasty-hspec
       - temporary
       - text
+      - time
       - yaml

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -228,12 +228,13 @@ instance L.ToHtml RevisionDiffs where
             L.th_ "Subject"
           foldMap renderRevision revs
 
-      renderRevision Git.Revision{..} =
+      renderRevision rev@Git.Revision{..} =
         L.tr_ $
-          L.td_ (L.toHtml abbrevHash) <>
-          L.td_ (L.toHtml commitDate) <>
+          L.td_ (L.toHtml (Git.abbrevHash rev)) <>
+          L.td_ (L.toHtml (formatDateAndTime commitDate)) <>
           L.td_ (L.toHtml authorName) <>
           L.td_ (L.toHtml subject)
+
 
 data ChangeLog
   = ChangeLog
@@ -259,7 +260,7 @@ instance L.ToHtml ChangeLog where
       formatDate = Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat Nothing)
       renderRevision (uri, Git.Revision{commitDate, authorName, subject}) =
         L.tr_ $
-          L.td_ (L.toHtml commitDate) <>
+          L.td_ (L.toHtml (formatDateAndTime commitDate)) <>
           L.td_ (renderRepoURL uri) <>
           L.td_ (L.toHtml subject) <>
           L.td_ (L.toHtml authorName)
@@ -270,6 +271,12 @@ instance L.ToHtml ChangeLog where
         in L.a_ [L.href_ (toS $ uriToString (const "") uri "")] (L.toHtml cleanPath)
       renderRepoURL uri@(Git.SCP _) = L.toHtml (Git.toText uri)
 
+
+-- | Format a UTC time in the standard way for our HTML.
+--
+-- This means ISO with numeric timezone.
+formatDateAndTime :: Time.UTCTime -> Text
+formatDateAndTime = toS . Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat (Just "%H:%M:%S%z"))
 
 flattenChangelog
   :: Map Kube.ImageName (Either Engine.Error (Git.URL, [Git.Revision]))

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -58,6 +58,7 @@ revisions differ = do
   pure . RevisionDiffs $ Engine.revisionDiffs <$> diff
 
 
+-- | Wrap an HTML "page" with all of our standard boilerplate.
 standardPage :: Monad m => Text -> L.HtmlT m () -> L.HtmlT m ()
 standardPage title content =
   L.doctypehtml_ $ do
@@ -89,7 +90,8 @@ instance L.ToHtml RootPage where
           Nothing -> panic $ toS path <> " is not a valid relative URI"
           Just path' -> toS (uriToString identity (path' `relativeTo` externalURL) "")
 
-
+-- | The images that differ between Kubernetes objects.
+-- Newtype wrapper is to let us provide nice HTML.
 newtype ImageDiffs = ImageDiffs (Maybe (Map Kube.KubeID [Kube.ImageDiff])) deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON ImageDiffs where

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -249,7 +249,7 @@ instance L.ToHtml ChangeLog where
         L.th_ "Date"
         L.th_ "Subject"
         L.th_ "Author"
-      foldMap renderRevision (sortOn Git.commitDate (Map.keys (flattenChangelog changelog)))
+      foldMap renderRevision (reverse (sortOn Git.commitDate (Map.keys (flattenChangelog changelog))))
     L.h2_ (L.toHtml ("This week" :: Text))
     L.h2_ (L.toHtml ("Last week" :: Text))
     where

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -258,11 +258,11 @@ instance L.ToHtml ChangeLog where
     L.h2_ (L.toHtml ("Last week" :: Text))
     where
       formatDate = Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat Nothing)
-      renderRevision (uri, Git.Revision{commitDate, authorName, subject}) =
+      renderRevision (uri, Git.Revision{commitDate, authorName, subject, body}) =
         L.tr_ $
           L.td_ (L.toHtml (formatDateAndTime commitDate)) <>
           L.td_ (renderRepoURL uri) <>
-          L.td_ (L.toHtml subject) <>
+          L.td_ (L.pre_ (L.toHtml (subject <> maybe "" (\b -> "\n\n" <> b) body))) <>
           L.td_ (L.toHtml authorName)
       renderRepoURL (Git.URI uri) =
         let path = toS $ uriPath uri

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -253,17 +253,17 @@ instance L.ToHtml ChangeLog where
     case thisWeek of
       [] -> L.p_ "No changes in range"
       revs -> do
-        L.h2_ "This week"
+        L.h2_ (L.toHtml ("This week (" <> show (length revs) <> ")" :: Text))
         renderRevisions revs
     case lastWeek of
       [] -> pass
       revs -> do
-        L.h2_ "Last week"
+        L.h2_ (L.toHtml ("Last week (" <> show (length revs) <> ")" :: Text))
         renderRevisions revs
     case rest of
       [] -> pass
       revs -> do
-        L.h2_ "Earlier"
+        L.h2_ (L.toHtml ("Earlier (" <> show (length revs) <> ")" :: Text))
         renderRevisions revs
     where
       groupedChanges =

--- a/src/CompareRevisions/Config.hs
+++ b/src/CompareRevisions/Config.hs
@@ -14,6 +14,7 @@ module CompareRevisions.Config
   -- * YAML files
   ConfigRepo(..)
   , Environment(..)
+  , EnvironmentName
   , ImageConfig(..)
   , PolicyConfig(..)
   -- ** Valid configuration from YAML files

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -12,6 +12,7 @@ module CompareRevisions.Engine
   , newClusterDiffer
   , runClusterDiffer
   , getConfig
+  , loadChanges
   , ClusterDiff(..)
   , getCurrentDifferences
   ) where
@@ -24,6 +25,7 @@ import qualified Control.Logging as Log
 import Control.Monad.Except (withExceptT)
 import qualified Data.Map as Map
 import Data.String (String)
+import qualified Data.Time as Time
 import qualified Prometheus as Prom
 import System.Directory (canonicalizePath)
 import System.FilePath ((</>), takeDirectory)
@@ -278,6 +280,17 @@ compareImages gitRepoDir url branch sourceEnv targetEnv = withExceptT GitError $
   where
     checkoutPath = gitRepoDir </> "config-repo"
     loadEnv envPath = Kube.loadEnvFromDisk (checkoutPath </> envPath)
+
+
+-- | Find all the Git commits that have contributed to the change in a cluster
+-- over a time-span.
+loadChanges
+  :: ClusterDiffer  -- ^ Where the magic happens
+  -> FilePath  -- ^ Path to the Kubernetes YAMLs within the configuration repository
+  -> Time.Day  -- ^ The start date for Git commits. Commits earlier than 00:00Z on this date will be excluded.
+  -> IO (Map Kube.ImageName (Either Error [Git.Revision]))  -- ^ The changes, grouped by image.
+loadChanges _differ _envPath _start = pure Map.empty
+
 
 -- | Get the Git revision corresponding to a particular label. Error if we
 -- can't figure it out.

--- a/src/CompareRevisions/Engine.hs
+++ b/src/CompareRevisions/Engine.hs
@@ -11,6 +11,7 @@ module CompareRevisions.Engine
   , ClusterDiffer
   , newClusterDiffer
   , runClusterDiffer
+  , getConfig
   , ClusterDiff(..)
   , getCurrentDifferences
   ) where

--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -9,6 +9,7 @@ module CompareRevisions.Git
   , Hash(..)
   , RevSpec(..)
   , Revision(..)
+  , abbrevHash
   , GitError(..)
   , ensureCheckout
   , ensureCheckout'
@@ -18,12 +19,16 @@ module CompareRevisions.Git
   -- * Exported for testing purposes
   , runGit
   , runGitInRepo
+  , parseFullerRevisions
   ) where
 
 import Protolude hiding (hash)
 
 import qualified Control.Logging as Log
+import qualified Data.Attoparsec.Text as Atto
+import qualified Data.Attoparsec.Time as Atto
 import qualified Data.ByteString.Char8 as ByteString
+import qualified Data.Char as Char
 import qualified Data.Text as Text
 import qualified Data.Time as Time
 import Data.Aeson (FromJSON(..), ToJSON(..), withText)
@@ -69,7 +74,11 @@ instance FromJSON URL where
 newtype Branch = Branch Text deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
 
 -- | A SHA-1 hash for a Git revision.
-newtype Hash = Hash Text deriving (Eq, Ord, Show, Generic, FromJSON)
+newtype Hash = Hash { unHash :: Text } deriving (Eq, Ord, Show, Generic, FromJSON)
+
+-- | Parse a full SHA1 hash.
+fullHashParser :: Atto.Parser Hash
+fullHashParser = Hash . toS <$> Atto.takeWhile1 Char.isHexDigit
 
 -- | Specifies a revision in a Git repository.
 newtype RevSpec = RevSpec Text deriving (Eq, Ord, Show, Generic, FromJSON)
@@ -77,11 +86,64 @@ newtype RevSpec = RevSpec Text deriving (Eq, Ord, Show, Generic, FromJSON)
 -- | A Git revision.
 data Revision
   = Revision
-  { abbrevHash :: Text  -- TODO: Hash
-  , commitDate :: Text  -- TODO: some sort of data type
+  { revisionHash :: Hash
+  , commitDate :: Time.UTCTime
   , authorName :: Text
   , subject :: Text
+  , body :: Maybe Text
   } deriving (Eq, Ord, Show)
+
+-- | Get the abbreviated hash for a revision.
+--
+-- Does /not/ use the same algorithm as Git. Instead naively gets the last 8
+-- characters of the full hash.
+abbrevHash :: Revision -> Text
+abbrevHash = Text.takeEnd 8 . unHash . revisionHash
+
+-- | Parser for a "fuller" Git revision.
+--
+-- e.g.
+--
+-- commit 2c141409774c95bb0f8e6db9773c50de8c4dc6ea
+-- Author:     bryan <bryan@weave.works>
+-- AuthorDate: 2018-03-27 13:08:24 +0000
+-- Commit:     Weave Flux <support@weave.works>
+-- CommitDate: 2018-03-27 13:08:24 +0000
+--
+--     I want to leave a bit longer for cortex#681 to be tested in dev
+--
+--     - Locked: cortex:deployment/distributor
+--     - Updated policies: cortex:deployment/distributor
+fullerRevisionParser :: Atto.Parser Revision
+fullerRevisionParser = do
+  -- We're ignoring a lot of information here (the underscore-prefixed
+  -- variables). This is because we don't have actual use-cases for it yet.
+  -- Please feel free to store this information when we do need it.
+  fullHash <- "commit " *> fullHashParser <* Atto.endOfLine
+  _merge <- optional ("Merge: " *> (abbrevHashParser `Atto.sepBy` " ") <* Atto.endOfLine)
+  (authorName, _authorEmail) <- "Author:     " *> personParser <* Atto.endOfLine
+  _authorDate <- "AuthorDate: " *> Atto.utcTime <* Atto.endOfLine
+  (_committerName, _committerEmail) <- "Commit:    " *> personParser <* Atto.endOfLine
+  commitDate <- "CommitDate: " *> Atto.utcTime <* Atto.endOfLine
+  Atto.endOfLine
+  subject <- commitMessageLine
+  body <- optional ("    " *> Atto.endOfLine *> (Text.unlines <$> many commitMessageLine))
+  pure $ Revision fullHash commitDate authorName (toS subject) body
+  where
+    abbrevHashParser = Atto.takeWhile1 Char.isHexDigit
+    personParser = do
+      name <- Atto.takeTill (== '<')
+      email <- Atto.takeTill (== '>')
+      void $ Atto.char '>'
+      pure (Text.strip name, email)
+    commitMessageLine = "    " *> Atto.takeTill Atto.isEndOfLine <* Atto.endOfLine
+
+-- | Parse the output of `git log --format=fuller`.
+parseFullerRevisions :: MonadError GitError m => ByteString -> m [Revision]
+parseFullerRevisions input =
+  case Atto.parseOnly (fullerRevisionParser `Atto.sepBy` Atto.endOfLine) (toS input) of
+    Left err -> throwError $ InvalidRevision (toS err)
+    Right revs -> pure revs
 
 -- XXX: Not sure this is a good idea. Maybe use exceptions all the way
 -- through?
@@ -225,27 +287,24 @@ firstCommitSince repoPath (Branch branch) time = do
   -- practice, could either come up with a cleverer way of querying Git
   -- (preferred) or add a --before clause and exponentially back off until we
   -- reach a time greater than now.
-  let command = ["rev-list", "--first-parent", "--after=" <> isoTime, branch]
+  let command = ["rev-list", "--first-parent", "--after=" <> formatIsoTime time, branch]
   (out, _) <- runGitInRepo repoPath command
   pure $ Hash . toS <$> lastMay (ByteString.lines out)
-  where
-    isoTime = toS $ Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat (Just "%H:%M:%S")) time
+
+-- | Format a UTC time in ISO format.
+formatIsoTime :: Time.UTCTime -> Text
+formatIsoTime = toS . Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat (Just "%H:%M:%S %z"))
 
 getLog :: (MonadError GitError m, MonadIO m) => FilePath -> RevSpec -> RevSpec -> Maybe [FilePath] -> m [Revision]
 getLog repoPath (RevSpec start) (RevSpec end) paths = do
-  let command = ["log", "--first-parent", "--format=%h::%cd::%an::%s",  "--date=iso", range]
+  let command = ["log", "--first-parent", "--format=fuller", "--date=iso", range]
   let withFilter = command <> case paths of
                                 Nothing -> []
                                 Just ps -> ["--"] <> map toS ps
   (out, _) <- runGitInRepo repoPath withFilter
-  -- XXX: This will bork on the first invalid line. We can do better.
-  traverse parseRevision (ByteString.lines out)
+  parseFullerRevisions out
   where
     range = start <> ".." <> end
-    parseRevision line =
-      case Text.splitOn "::" (decodeUtf8 line) of
-        [hash, date, name, subject] -> pure (Revision hash date name subject)
-        _ -> throwError (InvalidRevision line)
 
 -- | Run 'git' in a repository.
 runGitInRepo :: (HasCallStack, MonadError GitError m, MonadIO m) => FilePath -> [Text] -> m (ByteString, ByteString)

--- a/tests/Git.hs
+++ b/tests/Git.hs
@@ -2,6 +2,9 @@
 module Git (tests) where
 
 import Protolude
+
+import qualified Data.ByteString.Char8 as ByteString
+import qualified Data.Time as Time
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Tasty (TestTree)
@@ -11,7 +14,7 @@ import qualified CompareRevisions.Git as Git
 import CompareRevisions.Server.Logging (withLogging, LogLevel(..))
 
 tests :: IO TestTree
-tests = testSpec "Git" $
+tests = testSpec "Git" $ do
   describe "ensureCheckout" $ do
     it "checks out a repository" $ withLogging LevelError $ withSystemTempDirectory "base-directory" $ \baseDir -> do
       let repoDir = baseDir </> "repo"
@@ -37,6 +40,70 @@ tests = testSpec "Git" $
       gitOp $ Git.ensureCheckout repoDir (Git.Branch "master") workingTreeDir
       contents <- readFile (workingTreeDir </> "hello")
       contents `shouldBe` "different content"
+  describe "log parsing" $
+    it "parses correct logs" $ do
+      let example = ByteString.unlines
+            [ "commit 5ec96380b9cede27c29f62a547a21c0e50c0e615"
+            , "Author:     Jonathan Lange <jml@mumak.net>"
+            , "AuthorDate: 2018-03-29 09:06:32 +0100"
+            , "Commit:     Jonathan Lange <jml@mumak.net>"
+            , "CommitDate: 2018-03-29 09:06:32 +0100"
+            , ""
+            , "    Show revision in output"
+            , ""
+            , "commit 2c141409774c95bb0f8e6db9773c50de8c4dc6ea"
+            , "Merge: 413dd27 06b2a5d"
+            , "Author:     bryan <bryan@weave.works>"
+            , "AuthorDate: 2018-03-27 13:08:24 +0000"
+            , "Commit:     Weave Flux <support@weave.works>"
+            , "CommitDate: 2018-03-27 13:08:24 +0000"
+            , ""
+            , "    I want to leave a bit longer for cortex#681 to be tested in dev"
+            , "    "
+            , "    - Locked: cortex:deployment/distributor"
+            , "    - Updated policies: cortex:deployment/distributor"
+            , ""
+            , "commit 66474fb8229ba7bcf52c228fda91fb89b0920fe7"
+            , "Author:     Jonathan Lange <jml@mumak.net>"
+            , "AuthorDate: 2018-03-29 08:35:51 +0100"
+            , "Commit:     Jonathan Lange <jml@mumak.net>"
+            , "CommitDate: 2018-03-29 08:35:51 +0100"
+            , ""
+            , "    List revisions in reverse chronological order"
+            ]
+      let parsed = Git.parseFullerRevisions example
+      parsed `shouldBe`
+        Right [ Git.Revision
+                { revisionHash = Git.Hash "5ec96380b9cede27c29f62a547a21c0e50c0e615"
+                , commitDate = Time.UTCTime
+                               { utctDay = Time.fromGregorian 2018 3 29
+                               , utctDayTime = Time.timeOfDayToTime $ Time.TimeOfDay 8 6 32
+                               }
+                , authorName = "Jonathan Lange"
+                , subject = "Show revision in output"
+                , body = Nothing
+                }
+              , Git.Revision
+                { revisionHash = Git.Hash "2c141409774c95bb0f8e6db9773c50de8c4dc6ea"
+                , commitDate = Time.UTCTime
+                               { utctDay = Time.fromGregorian 2018 3 27
+                               , utctDayTime = Time.timeOfDayToTime $ Time.TimeOfDay 13 8 24
+                               }
+                , authorName = "bryan"
+                , subject = "I want to leave a bit longer for cortex#681 to be tested in dev"
+                , body = Just "- Locked: cortex:deployment/distributor\n- Updated policies: cortex:deployment/distributor\n"
+                }
+              , Git.Revision
+                { revisionHash = Git.Hash "66474fb8229ba7bcf52c228fda91fb89b0920fe7"
+                , commitDate = Time.UTCTime
+                               { utctDay = Time.fromGregorian 2018 3 29
+                               , utctDayTime = Time.timeOfDayToTime $ Time.TimeOfDay 7 35 51
+                               }
+                , authorName = "Jonathan Lange"
+                , subject = "List revisions in reverse chronological order"
+                , body = Nothing
+                }
+              ]
 
 git :: MonadIO m => FilePath -> [Text] -> m ()
 git repo args = gitOp $ Git.runGitInRepo repo args


### PR DESCRIPTION
Generate a new report of what has changed on each cluster over the last couple of weeks, so we can easily tell anyone at the company how Weave Cloud has changed recently.

The output isn't perfect, but it's workable. There are probably outstanding issues in the code, I've tried to mark these with XXX where possible.

<img width="804" alt="screen shot 2018-04-04 at 12 16 03" src="https://user-images.githubusercontent.com/125674/38304734-4dd43b7e-3802-11e8-917c-b56660c9fcb0.png">
