### PR TITLE
Configuration for building Docker image via `stack`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,14 @@ packages:
 
 extra-deps:
   - logging-3.0.4
+
+image:
+  containers:
+    - base: "ubuntu:18.04"
+      name: "quay.io/weaveworks/compare-revisions"
+      executables:
+        - compare-revisions
+      entrypoints:
+        # This will generate an image called:
+        # `quay.io/weaveworks/compare-revisions-compare-revisions`
+        - compare-revisions


### PR DESCRIPTION
When we migrated to CircleCI 2.0, we went to a native Stack build process rather than our traditional Dockerized Makefile shenanigans. In the process, we lost our ability to build images.

This restores that ability. A future PR will integrate this with CI.