### PR TITLE
Install docker client in CI image during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
           paths:
             - /root/.stack
             - .stack-work
+
+      # fpco/stack-build doesn't include a docker client
+      - run: apt update && apt install -y docker.io
+
       - run:
           name: Tests
           command: stack test --skip-ghc-check --no-terminal


### PR DESCRIPTION
`setup_remote_docker` spins up a remote docker engine, and parameterises the environment accordingly; we still need a docker client, as there isn't one present in fpco/stack-build.