### PR TITLE
Link to GitHub

### DIFF
--- a/compare-revisions.cabal
+++ b/compare-revisions.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 71f6c2c9ccbfd7ed7a25467f36b1d6a7d269f13787947e5aec7e88ca9f22398a
+-- hash: 0a7d2a2e9aa6ce395a7f247713ea91d1e93e3a845749437bfd19cb8741ead8f0
 
 name:           compare-revisions
 version:        0.1.0
@@ -74,6 +74,7 @@ library
       CompareRevisions.Duration
       CompareRevisions.Engine
       CompareRevisions.Git
+      CompareRevisions.GitHub
       CompareRevisions.Kube
       CompareRevisions.Regex
       CompareRevisions.SCP

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -281,7 +281,15 @@ instance L.ToHtml ChangeLog where
 
 
 -- XXX: Is there a better return type for this?
-renderChangelogRevision :: Monad m => Git.URL -> Git.Revision -> L.HtmlT m ()
+-- | Render a Git revision, intended to be part of a changelog, as HTML.
+--
+-- Idea is to show everything we can about who made it and why, so that people
+-- reviewing it can gauge its user impact.
+renderChangelogRevision
+  :: Monad m
+  => Git.URL  -- ^ The URL of the Git repository that this revision is from
+  -> Git.Revision  -- ^ The revision to render
+  -> L.HtmlT m ()
 renderChangelogRevision gitUri Git.Revision{commitDate, authorName, subject, body} =
   L.li_ [L.class_ "revision"] $ do
     void $ L.div_ [L.class_ "subject"] (L.b_ (L.toHtml subject))

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -294,10 +294,12 @@ renderChangelogRevision gitUri Git.Revision{commitDate, authorName, subject, bod
   let gitHubRepo = GitHub.repositoryFromGitURL gitUri
   L.li_ [L.class_ "revision"] $ do
     void $ L.div_ [L.class_ "subject"] $ do
-      L.b_ (L.toHtml subject)
       case gitHubRepo of
-        Just repo -> mapM_ (linkToIssue repo) (GitHub.findIssues subject)
+        Just repo -> do
+          mapM_ (linkToIssue repo) (GitHub.findIssues subject)
+          " "
         Nothing -> pass
+      L.b_ (L.toHtml subject)
     void $ L.div_ [L.class_ "by-line"] $ do
       L.toHtml (authorName <> ", committed on " <> formatShortDate commitDate <> " to ")
       case gitHubRepo of

--- a/src/CompareRevisions/API.hs
+++ b/src/CompareRevisions/API.hs
@@ -277,12 +277,12 @@ instance L.ToHtml ChangeLog where
       groupByWeek = List.groupBy ((==) `on` (\(y, w, _) -> (y, w)) . WeekDate.toWeekDate . Time.utctDay . Git.commitDate . snd)
       formatDate = Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat Nothing)
       renderRevisions revs =
-        L.ul_ [L.class_ "revisions"] $ foldMap renderChangelogRevision revs
+        L.ul_ [L.class_ "revisions"] $ foldMap (uncurry renderChangelogRevision) revs
 
 
 -- XXX: Is there a better return type for this?
-renderChangelogRevision :: Monad m => (Git.URL, Git.Revision) -> L.HtmlT m ()
-renderChangelogRevision (gitUri, Git.Revision{commitDate, authorName, subject, body}) =
+renderChangelogRevision :: Monad m => Git.URL -> Git.Revision -> L.HtmlT m ()
+renderChangelogRevision gitUri Git.Revision{commitDate, authorName, subject, body} =
   L.li_ [L.class_ "revision"] $ do
     void $ L.div_ [L.class_ "subject"] (L.b_ (L.toHtml subject))
     void $ L.div_ [L.class_ "by-line"] $ do

--- a/src/CompareRevisions/GitHub.hs
+++ b/src/CompareRevisions/GitHub.hs
@@ -59,7 +59,7 @@ websiteURI Repository{organization, repositoryName} =
     , URI.uriRegName = "github.com"
     , URI.uriPort = ""
     }
-  , uriPath = toS (organization <> "/" <> repositoryName)
+  , uriPath = toS ("/" <> organization <> "/" <> repositoryName)
   }
 
 -- | Find references to all the GitHub issues within some text.

--- a/src/CompareRevisions/GitHub.hs
+++ b/src/CompareRevisions/GitHub.hs
@@ -1,0 +1,56 @@
+-- | Utilities for manipulating Git URLs based on GitHub conventions.
+module CompareRevisions.GitHub
+  ( Organization
+  , RepositoryName
+  , websiteURI
+  , getRepo
+  , repoPath
+  ) where
+
+import Protolude
+
+import qualified Data.Text as Text
+import Network.URI (URI(..))
+import qualified Network.URI as URI
+
+import qualified CompareRevisions.Git as Git
+import qualified CompareRevisions.SCP as SCP
+
+-- | A GitHub organization.
+type Organization = Text
+
+-- | The name of a repository.
+type RepositoryName = Text
+
+-- | Assuming a Git URL points to a GitHub repository, generate a URL for that
+-- repository's web page.
+websiteURI :: Git.URL -> Maybe URI
+websiteURI url@(Git.URI uri) =
+  Just $ uri { uriPath = toS (repoPath url) }
+websiteURI url@(Git.SCP scp) =
+  foreach (SCP.getHostname scp) $ \hostname ->
+    URI.nullURI
+    { uriScheme = "https:"
+    , uriAuthority = Just URI.URIAuth
+      { URI.uriUserInfo = ""
+      , URI.uriRegName = toS (SCP.unHostname hostname)
+      , URI.uriPort = ""
+      }
+    , uriPath = toS (repoPath url)
+    }
+
+-- | Get the path to the repository from the URL. Strips any preceding @/@.
+repoPath :: Git.URL -> Text
+repoPath uri =
+  let path = toS $ case uri of
+                     Git.SCP scp -> SCP.getFilePath scp
+                     Git.URI url -> uriPath url
+      withoutGit = fromMaybe path (Text.stripSuffix ".git" path)
+  in fromMaybe withoutGit (Text.stripPrefix "/" withoutGit)
+
+-- | Get the GitHub organization and repository from a Git URL.
+getRepo :: Git.URL -> Maybe (Organization, RepositoryName)
+getRepo uri =
+  case Text.splitOn "/" (repoPath uri) of
+    [org, repo] -> Just (org, repo)
+    _ -> Nothing


### PR DESCRIPTION
Link to the GitHub PR that made up a commit. It's not fool-proof, but it does a much better job, and will save me a lot of time.

<img width="800" alt="screen shot 2018-06-14 at 16 37 13" src="https://user-images.githubusercontent.com/125674/41422640-38229574-6ff1-11e8-9afb-949ca9f09f0a.png">

