### PR TITLE
Make abbrevHash similar to the git short hash

### DIFF
--- a/src/CompareRevisions/Git.hs
+++ b/src/CompareRevisions/Git.hs
@@ -95,10 +95,10 @@ data Revision
 
 -- | Get the abbreviated hash for a revision.
 --
--- Does /not/ use the same algorithm as Git. Instead naively gets the last 8
+-- Does /not/ use the same algorithm as Git. Instead naively gets the first 8
 -- characters of the full hash.
 abbrevHash :: Revision -> Text
-abbrevHash = Text.takeEnd 8 . unHash . revisionHash
+abbrevHash = Text.take 8 . unHash . revisionHash
 
 -- | Parser for a "fuller" Git revision.
 --


### PR DESCRIPTION
Take the first 8 characters, rather than the last, which is a closer approximation of how the git short hash is computed.